### PR TITLE
Fix color opacity in color-alpha and color-scale

### DIFF
--- a/src/partials/_color.scss
+++ b/src/partials/_color.scss
@@ -83,7 +83,7 @@ $config-use-mix-method: config.$use-mix-method !default;
 ///
 /// @param {color} $color
 ///   Color to be manipulated
-/// @param {number(unitless)} $opacity
+/// @param {number(unitless) | number(%)} $opacity
 ///   0-1 inclusive. 0 is invisible, 1 is fully opaque
 ///
 /// @returns {color(rgba)}
@@ -112,7 +112,7 @@ $config-use-mix-method: config.$use-mix-method !default;
 /// @param {number(%)} $percent [null]
 ///   Percent by which to be manipulated, can be positive or negative
 /// @param {number(unitless)} $opacity [null]
-///   0-1 inclusive
+///   0-1 inclusive, or percentage 0-100
 /// @param {boolean} $mix [$config-use-mix-method]
 ///   Use color.mix() or color.scale() to calculate new color.
 ///

--- a/src/partials/_color.scss
+++ b/src/partials/_color.scss
@@ -92,6 +92,9 @@ $config-use-mix-method: config.$use-mix-method !default;
   $color,
   $opacity
 ) {
+  @if v.is-percentage($opacity) {
+    $opacity: $opacity / 100;
+  }
   @return color.change($color, $alpha: $opacity);
 }
 
@@ -118,14 +121,19 @@ $config-use-mix-method: config.$use-mix-method !default;
 /// --------------------------------------------------------------------------
 @function color-scale(
   $color,
-  $percent,
+  $percent: null,
   $opacity: null,
   $mix: $config-use-mix-method
 ) {
-  @if $mix {
-    @return color-mix($color, $percent);
+  $_output: $color;
+  @if $percent {
+    @if $mix { $_output: color-mix($color, $percent); }
+    @else { $_output: color.scale($color, $lightness: $percent); }
   }
-  @return color.scale($color, $lightness: $percent);
+  @if $opacity {
+    @return color-alpha($_output, $opacity);
+  }
+  @return $_output;
 }
 
 // END !SECTION Color Modifications

--- a/test/unit/_color.spec.scss
+++ b/test/unit/_color.spec.scss
@@ -60,7 +60,7 @@
   }
 }
 
-// color-scale($color, $percent, $mix)
+// color-scale( $color, $percent, $opacity, $mix)
 // ===========================================================================
 @include true.test-module('color-scale [function]') {
   @include true.test('call color-mix with $mix: true') {
@@ -93,12 +93,22 @@
     $expected: color.scale(#1273e6, $lightness: 20%);
     @include true.assert-equal(meta.inspect($test), meta.inspect($expected));
   }
+
+  @include true.test('calculate opacity with given input') {
+    $test: stratus.color-scale(#1273e6, $opacity: 20%);
+    $expected: color.change(#1273e6, $alpha: 0.2);
+    @include true.assert-equal(meta.inspect($test), meta.inspect($expected));
+  }
 }
 // color-alpha($color, $opacity)
 // ===========================================================================
 @include true.test-module('color-alpha [function]') {
-  @include true.test('return adjusted opacity') {
+  @include true.test('return adjusted opacity with decimal input') {
     $test: stratus.color-alpha(#1273e6, 0.4);
+    $expected: color.change(#1273e6, $alpha: 0.4);
+  }
+  @include true.test('return adjusted opacity with percent input') {
+    $test: stratus.color-alpha(#1273e6, 40%);
     $expected: color.change(#1273e6, $alpha: 0.4);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- This should finish the sentence "If accepted, this PR will..." -->

## Description
<!--- Describe your changes in detail, list each logical change and explain why that change was made. -->
* Added a way for the `color-alpha` function to handle percentages
* Added the opacity functionality back into the `color-scale` function
* Added new tests to ensure the new features are working correctly

## Motivation and Context
The documentation states that the opacity should be adjustable through the `color-scale` function, and the function takes an argument for it, but did nothing with this information.

Adding the ability for `color-alpha` to take a percentage was born from using these functions in a real world product where it didn't make sense or was annoying to use a decimal representation. 

## How Has This Been Tested?
I've added a test to make sure the `color-alpha` function generates the correct color with both methods. A test was also added to the `color-scale` function to make sure it passes the correct information to `color-alpha`

These changes don't affect any other area of the code, so it should be a clean pull.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)